### PR TITLE
py3 Fix: TypeError in string slice index

### DIFF
--- a/pycdb/pycdb.py
+++ b/pycdb/pycdb.py
@@ -505,7 +505,7 @@ class PyCdb(object):
                 buf += ch
 
                 if len(buf) >= self.output_buf_max:
-                    buf = buf[self.output_buf_max / 2:]
+                    buf = buf[int(self.output_buf_max / 2):]
 
                 # look for prompt
                 if lastch == '>' and ch == ' ' and self.qthread.queue.empty():


### PR DESCRIPTION
`TypeError: slice indices must be integers or None or have an __index__ method`
In python 2 an integer divided by an integer resulted in an integer
In python 3 result is now float

[Edit] I found this by running `!address` in a large program. :)